### PR TITLE
Data compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ __pycache__/
 data/*
 !data/assets/*
 
+# training
+checkpoint/*
+checkpoints/*
+wandb/*
+
 # Distribution / packaging
 .Python
 build/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ uv sync --dev
 uv run pre-commit install
 ```
 
-4. Initialize full data pipeline (download + preprocess).
+4. Initialize standard data pipeline (download + preprocess).
 
 ```bash
 uv run htt-init --threads 8
@@ -34,17 +34,25 @@ uv run htt-init --threads 8
 By default this runs:
 
 1. `htt-get-data --full`
-2. `htt-preprocess --threads <N> --out-dir data/full --merge synthetic symbols`
+2. `htt-preprocess --threads <N> --out-dir data/full`
 
 5. For a quick mock/sample setup use:
 
 ```bash
-uv run htt-init --mock --threads 4
+uv run htt-init --mode mock --threads 4
 ```
 
 Mock mode runs excerpt download and preprocesses into `data/sample`.
 
-6. Train a baseline model.
+6. For extended preprocessing with additional merges use:
+
+```bash
+uv run htt-init --mode extended --threads 8
+```
+
+Extended mode runs full download and preprocesses into `data/extended` with `synthetic` and `symbols` merged.
+
+7. Train a baseline model.
 
 ```bash
 uv run htt-run fit --config configs/default.yaml
@@ -59,14 +67,18 @@ One-command initialization for dataset preparation.
 Options:
 
 1. `--threads`: number of worker processes passed to preprocessing (default: `1`)
-2. `--mock`: use excerpt dataset instead of full dataset
+2. `--mode`: initialization mode (default: `standard`)
+	- `mock`: excerpt dataset + preprocess to `data/sample`
+	- `standard`: full dataset + preprocess to `data/full`
+	- `extended`: full dataset + preprocess to `data/extended` with `synthetic` and `symbols` merge
 
 Examples:
 
 ```bash
 uv run htt-init
 uv run htt-init --threads 8
-uv run htt-init --mock --threads 4
+uv run htt-init --mode mock --threads 4
+uv run htt-init --mode extended --threads 8
 ```
 
 ### htt-get-data

--- a/README.md
+++ b/README.md
@@ -1,199 +1,226 @@
-# hand-to-tex
+# Hand-to-TeX
 
-Model for converting online handwritten mathematical expressions into LaTeX.
+Hand-to-TeX is a deep learning project for converting online handwritten mathematical expressions (InkML stroke data) into LaTeX.
+
+It includes the full workflow:
+
+- dataset download
+- preprocessing into efficient `.pt` tensors
+- model training and evaluation (PyTorch Lightning)
+- batch and interactive inference
 
 ## Quick Start
 
-This repository uses uv for dependency management.
+### 1. Prerequisites
 
-1. Clone the repository.
+- Python 3.12+
+- `uv` installed (`pip install uv`)
+
+### 2. Install dependencies
 
 ```bash
 git clone https://github.com/Projekt-Deep-Learning-2026/hand-to-tex.git
 cd hand-to-tex
-```
-
-2. Install dependencies.
-
-```bash
 uv sync --dev
 ```
 
-3. (Optional) install pre-commit hooks.
+### 3. Activate your virtual environment (recommended)
+
+If you activate `.venv`, you can run project commands directly without prefixing them with `uv run`.
 
 ```bash
-uv run pre-commit install
+# Git Bash (Windows)
+source .venv/Scripts/activate
+
+# PowerShell (Windows)
+.venv\Scripts\Activate.ps1
 ```
 
-4. Initialize standard data pipeline (download + preprocess).
+### 4. Run a prediction immediately (no training)
+
+This uses the checkpoint already included in the repository:
 
 ```bash
-uv run htt-init --threads 8
+htt-demo --ckpt data/models/last.ckpt --input tests/fixtures/sample.inkml
 ```
 
-By default this runs:
+You should see predicted TeX in logs and a rendered plot window.
 
-1. `htt-get-data --full`
-2. `htt-preprocess --threads <N> --out-dir data/full`
-
-5. For a quick mock/sample setup use:
+### 5. Prepare data with one command
 
 ```bash
-uv run htt-init --mode mock --threads 4
+htt-init --mode standard --threads 8
 ```
 
-Mock mode runs excerpt download and preprocesses into `data/sample`.
+### 6. Train
 
-6. For extended preprocessing with additional merges use:
+Training setup is managed by Lightning CLI through `htt-run` and YAML configs in `configs/`.
 
 ```bash
-uv run htt-init --mode extended --threads 8
+htt-run fit --config configs/default.yaml
 ```
 
-Extended mode runs full download and preprocesses into `data/extended` with `synthetic` and `symbols` merged.
-
-7. Train a baseline model.
+### 7. Evaluate
 
 ```bash
-uv run htt-run fit --config configs/default.yaml
+htt-run test --config configs/default.yaml --ckpt_path checkpoints/last.ckpt
 ```
 
-## Scripts
+## Core CLI Commands
 
-### htt-init
+Installed entrypoints:
 
-One-command initialization for dataset preparation.
+- `htt-init`: one-command data initialization (download + preprocess)
+- `htt-get-data`: download raw MathWriting archives
+- `htt-preprocess`: convert InkML to `.pt` tensors
+- `htt-run`: train/test with Lightning CLI
+- `htt-demo`: run inference on files or interactive canvas
 
-Options:
+Use `<command> --help` for full options.
 
-1. `--threads`: number of worker processes passed to preprocessing (default: `1`)
-2. `--mode`: initialization mode (default: `standard`)
-	- `mock`: excerpt dataset + preprocess to `data/sample`
-	- `standard`: full dataset + preprocess to `data/full`
-	- `extended`: full dataset + preprocess to `data/extended` with `synthetic` and `symbols` merge
+## Data Initialization Modes (`htt-init`)
+
+`htt-init` supports three modes via `--mode`:
+
+| Mode | What it does | Output |
+|---|---|---|
+| `mock` | Downloads excerpt dataset and preprocesses with synthetic/symbol merges | `data/sample` |
+| `standard` | Downloads full dataset and preprocesses base splits | `data/full` |
+| `extended` | Downloads full dataset and preprocesses with synthetic/symbol merges | `data/extended` |
 
 Examples:
 
 ```bash
-uv run htt-init
-uv run htt-init --threads 8
-uv run htt-init --mode mock --threads 4
-uv run htt-init --mode extended --threads 8
+# Fast local check / small data
+htt-init --mode mock --threads 4
+
+# Standard full-data setup
+htt-init --mode standard --threads 8
+
+# Extended setup with extra merged data
+htt-init --mode extended --threads 8
 ```
 
-### htt-get-data
+## Manual Data Pipeline
 
-Download dataset archives.
-
-Options:
-
-1. `--full`: download full MathWriting dataset
-
-Examples:
+### Download raw data
 
 ```bash
-uv run htt-get-data
-uv run htt-get-data --full
+# Excerpt dataset
+htt-get-data
+
+# Full dataset
+htt-get-data --full
 ```
 
-### htt-preprocess
-
-Convert InkML files to tensor samples in `.pt` format.
-
-Common options:
-
-1. `--root`: source dataset root (default: `data/mathwriting-2024`)
-2. `--vocab`: vocabulary path (default: `data/assets/vocab.json`)
-3. `--threads`: number of worker processes
-4. `--splits`: selected splits to preprocess (`train`, `valid`, `test`)
-5. `--merge`: additional folders from `--root` to merge into selected splits
-6. `--out-dir`: output directory for generated `.pt` files
-7. `--start-idx`: skip first N files
-8. `--capacity`: limit number of kept samples per split
-9. `--max-tokens`: filter out long token sequences
-10. `--max-tracepoints`: filter out long trace sequences
-
-Examples:
+### Preprocess raw InkML into `.pt`
 
 ```bash
-uv run htt-preprocess --threads 12 --splits train valid test
-uv run htt-preprocess --threads 4 --splits test
-uv run htt-preprocess --threads 8 --out-dir data/full --merge synthetic symbols
+htt-preprocess --root data/mathwriting-2024 --out-dir data/full --threads 8
 ```
 
-### htt-run
+Common useful options:
 
-Entry point for the project runtime CLI.
+- `--splits train valid test`
+- `--merge synthetic symbols`
+- `--capacity <N>`
+- `--max-tokens <N>`
+- `--max-tracepoints <N>`
+- `--start-idx <N>`
 
-## Dataset
+## Training and Evaluation
 
-The project uses Google MathWriting (InkML-based online handwriting).
+This project uses Lightning CLI for training setup, configuration, and command routing (`fit`, `test`).
 
-Important raw splits include:
 
-1. train
-2. valid
-3. test
-4. symbols
-5. synthetic
-
-Use normalized labels as training targets.
-
-## Training
-
-Configuration profiles are stored in `configs/`.
-
-1. `configs/default.yaml`: full training profile (`data/full`)
-2. `configs/short.yaml`: short profile for faster experiments (`data/shorter`)
-
-Train with full profile:
+### Train with the default profile
 
 ```bash
-uv run htt-run fit --config configs/default.yaml
+htt-run fit --config configs/default.yaml
 ```
 
-Train with short profile:
+### Train on a different processed dataset root
 
 ```bash
-uv run htt-run fit --config configs/short.yaml
+htt-run fit --config configs/default.yaml --data.root data/extended
 ```
 
-Override values from CLI (example):
+### Quick sanity training on smaller data
 
 ```bash
-uv run htt-run fit --config configs/short.yaml --trainer.max_epochs 5 --data.batch_size 64
+htt-run fit --config configs/short.yaml --data.root data/sample --trainer.max_epochs 2
 ```
 
-Run test with a checkpoint:
+### Test a checkpoint
 
 ```bash
-uv run htt-run test --config configs/default.yaml --ckpt_path path/to/checkpoint.ckpt
+htt-run test --config configs/default.yaml --ckpt_path checkpoints/last.ckpt
 ```
 
-## Weights & Biases (WandB)
+## Inference / Demo
 
-Project dashboard:
+### Batch inference from one file
 
-- https://wandb.ai/dl-26-uniwroc-team1/hand-to-tex
+```bash
+htt-demo --ckpt data/models/last.ckpt --input tests/fixtures/sample.inkml
+```
 
+### Batch inference from directory
+
+```bash
+htt-demo --ckpt data/models/last.ckpt --input data/mathwriting-2024/test
+```
+
+### Save visualization images
+
+```bash
+htt-demo --ckpt data/models/last.ckpt --input tests/fixtures --save-img
+```
+
+### Interactive drawing mode
+
+```bash
+htt-demo --ckpt data/models/last.ckpt --interactive
+```
+
+## Configuration Profiles
+
+- `configs/default.yaml`: main training profile, expects processed data in `data/full`.
+- `configs/short.yaml`: lighter profile for short experiments.
+
+Both are standard Lightning CLI configs and can be overridden from command line.
 
 ## Development
 
 Run tests:
 
 ```bash
-uv run pytest
+pytest
 ```
 
-Lint and format checks:
+Run lint/format checks:
 
 ```bash
-uv run ruff check .
-uv run ruff format .
+ruff check .
+ruff format .
 ```
 
-## Notes
+Install pre-commit hooks:
 
-1. The training module logs text metrics and exact-match ratio on validation and test.
-2. WandB logger is configured through Lightning config files.
-3. If you change dataset paths or vocabulary, update the selected config profile.
+```bash
+pre-commit install
+```
+
+## Project Structure
+
+```text
+configs/                # training profiles
+scripts/                # CLI scripts: init/download/preprocess/demo
+src/hand_to_tex/        # core package: datasets, model, utils, runtime CLI
+tests/                  # unit tests
+data/                   # raw and processed datasets, checkpoints
+```
+
+## License
+
+MIT. See `LICENSE`.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -129,7 +129,7 @@ trainer:
   model_registry: null
 model:
   vocab_path: &vocab_path data/assets/vocab.json
-  pretrained_model_path: saved_models/last.ckpt
+  pretrained_model_path: null
   d_model: 256
   nhead: 8
   num_encoder_layers: 4

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -147,6 +147,7 @@ data:
   batch_size: 256
   num_workers: 7
   pin_memory: true
+  min_len: 7
 optimizer: null
 lr_scheduler: null
 ckpt_path: null

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -8,7 +8,7 @@ trainer:
   logger:
   - class_path: lightning.pytorch.loggers.WandbLogger
     init_args:
-      name: L40S-HTT-FULL
+      name: L40S-HTT-EXTENDED
       save_dir: .
       version: null
       offline: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ ignore = ["E501"]
 [project.scripts]
 htt-get-data = "scripts.download_data:main"
 htt-preprocess = "scripts.preprocess:main"
+htt-demo = "scripts.demo:main"
 htt-init = "scripts.init:main"
 htt-run = "hand_to_tex.cli.run:main"
 

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,0 +1,126 @@
+import argparse
+import tkinter as tk
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import torch
+
+from hand_to_tex.datasets.dataset import _HMEDatasetBase
+from hand_to_tex.datasets.ink_data import InkData
+from hand_to_tex.models.lit_module import HMELightningModule
+from hand_to_tex.utils import logger
+from hand_to_tex.utils.interactive import HMEDrawingApp
+
+
+def run_batch_inference(
+    input_path_str: str,
+    model: HMELightningModule,
+    device: torch.device,
+    save_img: bool,
+):
+    input_path = Path(input_path_str)
+
+    if input_path.is_file():
+        inkml_files = [input_path]
+    elif input_path.is_dir():
+        inkml_files = list(input_path.rglob("*.inkml"))
+    else:
+        raise FileNotFoundError(f"Invalid input path: {input_path}")
+
+    if not inkml_files:
+        logger.warning(f"No .inkml files found in {input_path}")
+        return
+
+    for inkml_path in inkml_files:
+        logger.info(f"\nProcessing: {inkml_path.name}")
+        ink = InkData.load(inkml_path)
+
+        features = _HMEDatasetBase.extract_features(ink)
+
+        if features.size(0) == 0:
+            logger.warning("This .inkml file doesn't contain any traces")
+            continue
+
+        features_batched = features.unsqueeze(0).to(device)
+        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=device)
+
+        with torch.inference_mode():
+            generated_tokens = model.generate(src=features_batched, src_lengths=lengths)
+
+        predicted_expr = model._to_expr(generated_tokens[0]).replace(" ", "")
+
+        expected_expr = ink.tex_norm
+
+        logger.info("=" * 50)
+        logger.info(f"Sample ID: {ink.sample_id}")
+        logger.info(f"Real TeX:  {expected_expr}")
+        logger.info(f"Predicted: {predicted_expr}")
+        logger.info("=" * 50)
+
+        fig, ax = ink.to_fig()
+
+        new_title = (
+            f"Sample: {ink.sample_id} ({ink.tag})\n"
+            f"Expected: ${expected_expr}$\n"
+            f"Predicted: ${predicted_expr}$"
+        )
+        title_color = "darkgreen" if expected_expr == predicted_expr else "darkred"
+
+        ax.set_title(new_title, color=title_color, pad=15)
+
+        if save_img:
+            out_filename = f"pred_{ink.sample_id}.png"
+            fig.savefig(out_filename, bbox_inches="tight", dpi=150)
+            logger.info(f"Visualization saved to {out_filename}")
+            plt.close(fig)
+        else:
+            plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HME Demo: Batch Inference or Interactive App")
+    parser.add_argument("--ckpt", type=str, required=True, help="checkpoint .ckpt file path")
+    parser.add_argument("--input", type=str, help="Path to .inkml file or directory")
+    parser.add_argument(
+        "--interactive", action="store_true", help="Launch interactive drawing canvas"
+    )
+    parser.add_argument(
+        "--vocab", type=str, default="data/assets/vocab.json", help="Vocabulary .json file path"
+    )
+    parser.add_argument("--save-img", action="store_true", help="Save the visualization to a .png")
+    args = parser.parse_args()
+
+    if not args.interactive and not args.input:
+        parser.error("--input is required unless --interactive is used.")
+
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+
+    logger.info(f"Initialising inference on: {device}")
+    logger.info(f"Loading model weights from: {args.ckpt}")
+
+    model = HMELightningModule.load_from_checkpoint(
+        checkpoint_path=args.ckpt,
+        vocab_path=args.vocab,
+        map_location=device,
+        pretrained_model_path=None,
+        weights_only=True,
+    )
+    model.eval()
+    model.to(device)
+
+    if args.interactive:
+        logger.info("Launching interactive mode...")
+        root = tk.Tk()
+        _app = HMEDrawingApp(root, model, device)
+        root.mainloop()
+    else:
+        run_batch_inference(args.input, model, device, args.save_img)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,5 +1,4 @@
 import argparse
-import tkinter as tk
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -9,16 +8,22 @@ from hand_to_tex.datasets.dataset import _HMEDatasetBase
 from hand_to_tex.datasets.ink_data import InkData
 from hand_to_tex.models.lit_module import HMELightningModule
 from hand_to_tex.utils import logger
-from hand_to_tex.utils.interactive import HMEDrawingApp
 
 
-def run_batch_inference(
-    input_path_str: str,
-    model: HMELightningModule,
-    device: torch.device,
-    save_img: bool,
-):
-    input_path = Path(input_path_str)
+def main():
+    parser = argparse.ArgumentParser(description="Inference .inkml files with your model")
+    parser.add_argument("--input", type=str, required=True, help="Path to .inkml file or directory")
+    parser.add_argument("--ckpt", type=str, required=True, help="checkpoint .ckpt file path")
+    parser.add_argument(
+        "--vocab",
+        type=str,
+        default="data/assets/vocab.json",
+        help="Vocabulary .json file path",
+    )
+    parser.add_argument("--save-img", action="store_true", help="Save the visualization to a .png")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
 
     if input_path.is_file():
         inkml_files = [input_path]
@@ -30,68 +35,6 @@ def run_batch_inference(
     if not inkml_files:
         logger.warning(f"No .inkml files found in {input_path}")
         return
-
-    for inkml_path in inkml_files:
-        logger.info(f"\nProcessing: {inkml_path.name}")
-        ink = InkData.load(inkml_path)
-
-        features = _HMEDatasetBase.extract_features(ink)
-
-        if features.size(0) == 0:
-            logger.warning("This .inkml file doesn't contain any traces")
-            continue
-
-        features_batched = features.unsqueeze(0).to(device)
-        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=device)
-
-        with torch.inference_mode():
-            generated_tokens = model.generate(src=features_batched, src_lengths=lengths)
-
-        predicted_expr = model._to_expr(generated_tokens[0]).replace(" ", "")
-
-        expected_expr = ink.tex_norm
-
-        logger.info("=" * 50)
-        logger.info(f"Sample ID: {ink.sample_id}")
-        logger.info(f"Real TeX:  {expected_expr}")
-        logger.info(f"Predicted: {predicted_expr}")
-        logger.info("=" * 50)
-
-        fig, ax = ink.to_fig()
-
-        new_title = (
-            f"Sample: {ink.sample_id} ({ink.tag})\n"
-            f"Expected: ${expected_expr}$\n"
-            f"Predicted: ${predicted_expr}$"
-        )
-        title_color = "darkgreen" if expected_expr == predicted_expr else "darkred"
-
-        ax.set_title(new_title, color=title_color, pad=15)
-
-        if save_img:
-            out_filename = f"pred_{ink.sample_id}.png"
-            fig.savefig(out_filename, bbox_inches="tight", dpi=150)
-            logger.info(f"Visualization saved to {out_filename}")
-            plt.close(fig)
-        else:
-            plt.show()
-
-
-def main():
-    parser = argparse.ArgumentParser(description="HME Demo: Batch Inference or Interactive App")
-    parser.add_argument("--ckpt", type=str, required=True, help="checkpoint .ckpt file path")
-    parser.add_argument("--input", type=str, help="Path to .inkml file or directory")
-    parser.add_argument(
-        "--interactive", action="store_true", help="Launch interactive drawing canvas"
-    )
-    parser.add_argument(
-        "--vocab", type=str, default="data/assets/vocab.json", help="Vocabulary .json file path"
-    )
-    parser.add_argument("--save-img", action="store_true", help="Save the visualization to a .png")
-    args = parser.parse_args()
-
-    if not args.interactive and not args.input:
-        parser.error("--input is required unless --interactive is used.")
 
     if torch.cuda.is_available():
         device = torch.device("cuda")
@@ -113,13 +56,49 @@ def main():
     model.eval()
     model.to(device)
 
-    if args.interactive:
-        logger.info("Launching interactive mode...")
-        root = tk.Tk()
-        _app = HMEDrawingApp(root, model, device)
-        root.mainloop()
-    else:
-        run_batch_inference(args.input, model, device, args.save_img)
+    for inkml_path in inkml_files:
+        logger.info(f"\nProcessing: {inkml_path.name}")
+        ink = InkData.load(inkml_path)
+
+        features = _HMEDatasetBase.extract_features(ink)
+
+        if features.size(0) == 0:
+            logger.warning("This .inkml file doesn't contain any traces")
+            continue
+
+        features_batched = features.unsqueeze(0).to(device)
+        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=device)
+
+        with torch.inference_mode():
+            generated_tokens = model.generate(src=features_batched, src_lengths=lengths)
+
+        predicted_expr = model._to_expr(generated_tokens[0]).replace(" ", "")
+        expected_expr = ink.tex_norm
+
+        logger.info("=" * 50)
+        logger.info(f"Sample ID: {ink.sample_id}")
+        logger.info(f"Real TeX:  {expected_expr}")
+        logger.info(f"Predicted: {predicted_expr}")
+        logger.info("=" * 50)
+
+        fig, ax = ink.to_fig()
+
+        new_title = (
+            f"Sample: {ink.sample_id} ({ink.tag})\n"
+            f"Expected: ${expected_expr}$\n"
+            f"Predicted: ${predicted_expr}$"
+        )
+        title_color = "darkgreen" if expected_expr == predicted_expr else "darkred"
+
+        ax.set_title(new_title, color=title_color, pad=15)
+
+        if args.save_img:
+            out_filename = f"pred_{ink.sample_id}.png"
+            fig.savefig(out_filename, bbox_inches="tight", dpi=150)
+            logger.info(f"Visualization saved to {out_filename}")
+            plt.close(fig)
+        else:
+            plt.show()
 
 
 if __name__ == "__main__":

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,4 +1,5 @@
 import argparse
+import tkinter as tk
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -8,22 +9,16 @@ from hand_to_tex.datasets.dataset import _HMEDatasetBase
 from hand_to_tex.datasets.ink_data import InkData
 from hand_to_tex.models.lit_module import HMELightningModule
 from hand_to_tex.utils import logger
+from hand_to_tex.utils.interactive import HMEDrawingApp
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Inference .inkml files with your model")
-    parser.add_argument("--input", type=str, required=True, help="Path to .inkml file or directory")
-    parser.add_argument("--ckpt", type=str, required=True, help="checkpoint .ckpt file path")
-    parser.add_argument(
-        "--vocab",
-        type=str,
-        default="data/assets/vocab.json",
-        help="Vocabulary .json file path",
-    )
-    parser.add_argument("--save-img", action="store_true", help="Save the visualization to a .png")
-    args = parser.parse_args()
-
-    input_path = Path(args.input)
+def run_batch_inference(
+    input_path_str: str,
+    model: HMELightningModule,
+    device: torch.device,
+    save_img: bool,
+):
+    input_path = Path(input_path_str)
 
     if input_path.is_file():
         inkml_files = [input_path]
@@ -35,6 +30,68 @@ def main():
     if not inkml_files:
         logger.warning(f"No .inkml files found in {input_path}")
         return
+
+    for inkml_path in inkml_files:
+        logger.info(f"\nProcessing: {inkml_path.name}")
+        ink = InkData.load(inkml_path)
+
+        features = _HMEDatasetBase.extract_features(ink)
+
+        if features.size(0) == 0:
+            logger.warning("This .inkml file doesn't contain any traces")
+            continue
+
+        features_batched = features.unsqueeze(0).to(device)
+        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=device)
+
+        with torch.inference_mode():
+            generated_tokens = model.generate(src=features_batched, src_lengths=lengths)
+
+        predicted_expr = model._to_expr(generated_tokens[0]).replace(" ", "")
+
+        expected_expr = ink.tex_norm
+
+        logger.info("=" * 50)
+        logger.info(f"Sample ID: {ink.sample_id}")
+        logger.info(f"Real TeX:  {expected_expr}")
+        logger.info(f"Predicted: {predicted_expr}")
+        logger.info("=" * 50)
+
+        fig, ax = ink.to_fig()
+
+        new_title = (
+            f"Sample: {ink.sample_id} ({ink.tag})\n"
+            f"Expected: ${expected_expr}$\n"
+            f"Predicted: ${predicted_expr}$"
+        )
+        title_color = "darkgreen" if expected_expr == predicted_expr else "darkred"
+
+        ax.set_title(new_title, color=title_color, pad=15)
+
+        if save_img:
+            out_filename = f"pred_{ink.sample_id}.png"
+            fig.savefig(out_filename, bbox_inches="tight", dpi=150)
+            logger.info(f"Visualization saved to {out_filename}")
+            plt.close(fig)
+        else:
+            plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HME Demo: Batch Inference or Interactive App")
+    parser.add_argument("--ckpt", type=str, required=True, help="checkpoint .ckpt file path")
+    parser.add_argument("--input", type=str, help="Path to .inkml file or directory")
+    parser.add_argument(
+        "--interactive", action="store_true", help="Launch interactive drawing canvas"
+    )
+    parser.add_argument(
+        "--vocab", type=str, default="data/assets/vocab.json", help="Vocabulary .json file path"
+    )
+    parser.add_argument("--save-img", action="store_true", help="Save the visualization to a .png")
+    args = parser.parse_args()
+
+    if not args.interactive and not args.input:
+        parser.error("--input is required unless --interactive is used.")
 
     if torch.cuda.is_available():
         device = torch.device("cuda")
@@ -56,49 +113,13 @@ def main():
     model.eval()
     model.to(device)
 
-    for inkml_path in inkml_files:
-        logger.info(f"\nProcessing: {inkml_path.name}")
-        ink = InkData.load(inkml_path)
-
-        features = _HMEDatasetBase.extract_features(ink)
-
-        if features.size(0) == 0:
-            logger.warning("This .inkml file doesn't contain any traces")
-            continue
-
-        features_batched = features.unsqueeze(0).to(device)
-        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=device)
-
-        with torch.inference_mode():
-            generated_tokens = model.generate(src=features_batched, src_lengths=lengths)
-
-        predicted_expr = model._to_expr(generated_tokens[0]).replace(" ", "")
-        expected_expr = ink.tex_norm
-
-        logger.info("=" * 50)
-        logger.info(f"Sample ID: {ink.sample_id}")
-        logger.info(f"Real TeX:  {expected_expr}")
-        logger.info(f"Predicted: {predicted_expr}")
-        logger.info("=" * 50)
-
-        fig, ax = ink.to_fig()
-
-        new_title = (
-            f"Sample: {ink.sample_id} ({ink.tag})\n"
-            f"Expected: ${expected_expr}$\n"
-            f"Predicted: ${predicted_expr}$"
-        )
-        title_color = "darkgreen" if expected_expr == predicted_expr else "darkred"
-
-        ax.set_title(new_title, color=title_color, pad=15)
-
-        if args.save_img:
-            out_filename = f"pred_{ink.sample_id}.png"
-            fig.savefig(out_filename, bbox_inches="tight", dpi=150)
-            logger.info(f"Visualization saved to {out_filename}")
-            plt.close(fig)
-        else:
-            plt.show()
+    if args.interactive:
+        logger.info("Launching interactive mode...")
+        root = tk.Tk()
+        _app = HMEDrawingApp(root, model, device)
+        root.mainloop()
+    else:
+        run_batch_inference(args.input, model, device, args.save_img)
 
 
 if __name__ == "__main__":

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -3,12 +3,16 @@ import subprocess
 
 from hand_to_tex.utils import logger
 
-PREPROCESS_DEFAULT_PARAMS = [
+PREPROCESS_EXTENDED_PARAMS = [
     "--out-dir",
-    "data/full",
+    "data/extended",
     "--merge",
     "synthetic",
     "symbols",
+]
+PREPROCESS_DEFAULT_PARAMS = [
+    "--out-dir",
+    "data/full",
 ]
 PREPROCESS_MOCK_PARAMS = [
     "--root",
@@ -19,19 +23,28 @@ PREPROCESS_MOCK_PARAMS = [
     "synthetic",
     "symbols",
 ]
+INIT_MODES = ["mock", "standard", "extended"]
 
 
-def run_init(threads: int, mock: bool = False) -> None:
-    if mock:
-        commands = [
-            ["htt-get-data"],
-            ["htt-preprocess", "--threads", str(threads)] + PREPROCESS_MOCK_PARAMS,
-        ]
-    else:
-        commands = [
-            ["htt-get-data", "--full"],
-            ["htt-preprocess", "--threads", str(threads)] + PREPROCESS_DEFAULT_PARAMS,
-        ]
+def run_init(threads: int, mode: str = "standard") -> None:
+    match mode:
+        case "mock":
+            commands = [
+                ["htt-get-data"],
+                ["htt-preprocess", "--threads", str(threads)] + PREPROCESS_MOCK_PARAMS,
+            ]
+        case "standard":
+            commands = [
+                ["htt-get-data", "--full"],
+                ["htt-preprocess", "--threads", str(threads)] + PREPROCESS_DEFAULT_PARAMS,
+            ]
+        case "extended":
+            commands = [
+                ["htt-get-data", "--full"],
+                ["htt-preprocess", "--threads", str(threads)] + PREPROCESS_EXTENDED_PARAMS,
+            ]
+        case _:
+            raise ValueError(f"Unsupported mode: {mode}")
 
     for command in commands:
         logger.info(f"Running: {' '.join(command)}")
@@ -40,7 +53,8 @@ def run_init(threads: int, mock: bool = False) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Initialize full dataset and run preprocessing in one command"
+        description="Initialize dataset and run preprocessing in one command",
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
         "--threads",
@@ -49,9 +63,15 @@ def main() -> None:
         help="Number of worker processes passed to htt-preprocess (default: 1)",
     )
     parser.add_argument(
-        "--mock",
-        action="store_true",
-        help="Use sample dataset (excerpt) and mock preprocessing defaults",
+        "--mode",
+        choices=INIT_MODES,
+        default="standard",
+        help=(
+            "Initialization mode:\n"
+            "  mock (~1.5 MB): excerpt dataset + preprocess to data/sample\n"
+            "  standard (~2 GB): full dataset + preprocess to data/full\n"
+            "  extended (~5 GB): full dataset + preprocess to data/extended with synthetic+symbols merge"
+        ),
     )
     args = parser.parse_args()
 
@@ -59,7 +79,7 @@ def main() -> None:
         parser.error(f"Argument --threads must be > 0 (got {args.threads})")
 
     try:
-        run_init(threads=args.threads, mock=args.mock)
+        run_init(threads=args.threads, mode=args.mode)
     except FileNotFoundError as exc:
         logger.error(f"Required CLI command not found: {exc}")
         raise SystemExit(1) from exc

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -40,13 +40,13 @@ def _process_single_file(
     FILTERED = ("filtered", None, ID)
     try:
         ink = InkData.load(pth)
-        fts = HMEDatasetRaw.extract_features(ink)
+        fts = HMEDatasetRaw.extract_features(ink).to(dtype=torch.float16)
 
         if fts.size(0) == 0:
             return EMPTY
 
         tokens = vocab.encode_expr(ink.tex_norm)
-        tokens = torch.tensor(tokens, dtype=torch.long)
+        tokens = torch.tensor(tokens, dtype=torch.int16)
 
         if (
             (max_tracepoints is not None and fts.size(0) > max_tracepoints)

--- a/src/hand_to_tex/datasets/collate.py
+++ b/src/hand_to_tex/datasets/collate.py
@@ -42,7 +42,7 @@ class HMECollateFunction:
         ft_lengths = torch.tensor([f.size(0) for f in features], dtype=torch.long)
         ts_lengths = torch.tensor([t.size(0) for t in tokens], dtype=torch.long)
 
-        padded_ft = pad_sequence(features, True, 0.0)
-        padded_ts = pad_sequence(tokens, True, self.pad_idx)
+        padded_ft = pad_sequence(features, True, 0.0).to(torch.float32)
+        padded_ts = pad_sequence(tokens, True, self.pad_idx).to(torch.long)
 
         return padded_ft, ft_lengths, padded_ts, ts_lengths

--- a/src/hand_to_tex/datasets/dataloader.py
+++ b/src/hand_to_tex/datasets/dataloader.py
@@ -30,6 +30,8 @@ class HMEDataLoaderFactory:
         batch_size: int,
         num_workers: int,
         pin_memory: bool,
+        min_len: int | None,
+        max_len: int | None,
     ):
         """Creates a DataLoader factory that can produce HMEDataset dataloaders
 
@@ -54,6 +56,8 @@ class HMEDataLoaderFactory:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.pin_memory = pin_memory
+        self.min_len = min_len
+        self.max_len = max_len
 
         self.collate_fn = HMECollateFunction(self.vocab)
 
@@ -71,8 +75,22 @@ class HMEDataLoaderFactory:
             DataLoader for training data with shuffling and drop_last=True
 
         """
-        dataset_type = HMEDatasetPreprocessed if self.processed else HMEDatasetRaw
-        dataset = dataset_type(root=self.root, split="train", vocab=self.vocab, transform=transform)
+        if self.processed:
+            dataset = HMEDatasetPreprocessed(
+                root=self.root,
+                split="train",
+                vocab=self.vocab,
+                transform=transform,
+                min_len=self.min_len,
+                max_len=self.max_len,
+            )
+        else:
+            dataset = HMEDatasetRaw(
+                root=self.root,
+                split="train",
+                vocab=self.vocab,
+                transform=transform,
+            )
 
         return DataLoader(
             dataset=dataset,
@@ -98,8 +116,22 @@ class HMEDataLoaderFactory:
             DataLoader for validation data without shuffling and drop_last=False
 
         """
-        dataset_type = HMEDatasetPreprocessed if self.processed else HMEDatasetRaw
-        dataset = dataset_type(root=self.root, split="valid", vocab=self.vocab, transform=transform)
+        if self.processed:
+            dataset = HMEDatasetPreprocessed(
+                root=self.root,
+                split="valid",
+                vocab=self.vocab,
+                transform=transform,
+                min_len=self.min_len,
+                max_len=self.max_len,
+            )
+        else:
+            dataset = HMEDatasetRaw(
+                root=self.root,
+                split="valid",
+                vocab=self.vocab,
+                transform=transform,
+            )
 
         return DataLoader(
             dataset=dataset,
@@ -124,8 +156,22 @@ class HMEDataLoaderFactory:
         DataLoader
             DataLoader for test data without shuffling and drop_last=False
         """
-        dataset_type = HMEDatasetPreprocessed if self.processed else HMEDatasetRaw
-        dataset = dataset_type(root=self.root, split="test", vocab=self.vocab, transform=transform)
+        if self.processed:
+            dataset = HMEDatasetPreprocessed(
+                root=self.root,
+                split="test",
+                vocab=self.vocab,
+                transform=transform,
+                min_len=self.min_len,
+                max_len=self.max_len,
+            )
+        else:
+            dataset = HMEDatasetRaw(
+                root=self.root,
+                split="test",
+                vocab=self.vocab,
+                transform=transform,
+            )
 
         return DataLoader(
             dataset=dataset,
@@ -160,10 +206,22 @@ class HMEDataLoaderFactory:
             Configured DataLoader for the specified split
         """
         split_name = split.lower()
-        dataset_type = HMEDatasetPreprocessed if self.processed else HMEDatasetRaw
-        dataset = dataset_type(
-            root=self.root, split=split_name, vocab=self.vocab, transform=transform
-        )
+        if self.processed:
+            dataset = HMEDatasetPreprocessed(
+                root=self.root,
+                split=split_name,
+                vocab=self.vocab,
+                transform=transform,
+                min_len=self.min_len,
+                max_len=self.max_len,
+            )
+        else:
+            dataset = HMEDatasetRaw(
+                root=self.root,
+                split=split_name,
+                vocab=self.vocab,
+                transform=transform,
+            )
 
         defaults = {
             "dataset": dataset,

--- a/src/hand_to_tex/datasets/dataloader.py
+++ b/src/hand_to_tex/datasets/dataloader.py
@@ -8,6 +8,9 @@ from hand_to_tex.datasets.collate import HMECollateFunction
 from hand_to_tex.datasets.dataset import HMEDatasetPreprocessed, HMEDatasetRaw
 from hand_to_tex.utils import LatexVocab
 
+Transformation = Callable[[Tensor], Tensor] | None
+HMEDataset = HMEDatasetPreprocessed | HMEDatasetRaw
+
 
 class HMEDataLoaderFactory:
     """Fabric class for initialization of HME dataset dataloaders
@@ -37,18 +40,22 @@ class HMEDataLoaderFactory:
 
         Parameters
         ----------
-        root : Path | str
+        root
             Path to the directory that contains splits like train, valid, test
-        processed : bool
+        processed
             Indicates whether data in `root` is `.inkml` (not processed) `.pt` (processed)
-        vocab : LatexVocab | None
+        vocab
             Latex vocabulary that will be used, if None then `LatexVocab.default()` will be used
-        batch_size : int
+        batch_size
             batch_size passed to torch `DataLoader`
-        num_workers : int
+        num_workers
             num_workers passed to torch `DataLoader`
-        pin_memory : bool
+        pin_memory
             pin_memory passed to torch `DataLoader`
+        min_len
+            Minimal length of sequence (tracepoints), only works for preprocessed datasets
+        max_len
+            Maximal length of sequence (tracepoints), only works for preprocessed datasets
         """
         self.root = Path(root)
         self.processed = processed
@@ -61,12 +68,12 @@ class HMEDataLoaderFactory:
 
         self.collate_fn = HMECollateFunction(self.vocab)
 
-    def train(self, transform: Callable[[Tensor], Tensor] | None = None) -> DataLoader:
+    def train(self, transform: Transformation) -> DataLoader:
         """Creates dataloader for `train` split
 
         Parameters
         ----------
-        transform : (Callable: `Tensor` -> `Tensor`) | None
+        transform
             Transform method passed to HMEDataset
 
         Returns
@@ -75,22 +82,7 @@ class HMEDataLoaderFactory:
             DataLoader for training data with shuffling and drop_last=True
 
         """
-        if self.processed:
-            dataset = HMEDatasetPreprocessed(
-                root=self.root,
-                split="train",
-                vocab=self.vocab,
-                transform=transform,
-                min_len=self.min_len,
-                max_len=self.max_len,
-            )
-        else:
-            dataset = HMEDatasetRaw(
-                root=self.root,
-                split="train",
-                vocab=self.vocab,
-                transform=transform,
-            )
+        dataset = self._get_dataset(split="train", transform=transform)
 
         return DataLoader(
             dataset=dataset,
@@ -102,12 +94,12 @@ class HMEDataLoaderFactory:
             collate_fn=self.collate_fn,
         )
 
-    def valid(self, transform: Callable[[Tensor], Tensor] | None = None) -> DataLoader:
+    def valid(self, transform: Transformation) -> DataLoader:
         """Creates dataloader for `valid` split
 
         Parameters
         ----------
-        transform : (Callable: `Tensor` -> `Tensor`) | None
+        transform
             Transform method passed to HMEDatasetRaw
 
         Returns
@@ -116,22 +108,7 @@ class HMEDataLoaderFactory:
             DataLoader for validation data without shuffling and drop_last=False
 
         """
-        if self.processed:
-            dataset = HMEDatasetPreprocessed(
-                root=self.root,
-                split="valid",
-                vocab=self.vocab,
-                transform=transform,
-                min_len=self.min_len,
-                max_len=self.max_len,
-            )
-        else:
-            dataset = HMEDatasetRaw(
-                root=self.root,
-                split="valid",
-                vocab=self.vocab,
-                transform=transform,
-            )
+        dataset = self._get_dataset(split="valid", transform=transform)
 
         return DataLoader(
             dataset=dataset,
@@ -143,12 +120,12 @@ class HMEDataLoaderFactory:
             collate_fn=self.collate_fn,
         )
 
-    def test(self, transform: Callable[[Tensor], Tensor] | None = None) -> DataLoader:
+    def test(self, transform: Transformation) -> DataLoader:
         """Creates dataloader for `test` split
 
         Parameters
         ----------
-        transform : (Callable: `Tensor` -> `Tensor`) | None
+        transform
             Transform method passed to HMEDatasetRaw
 
         Returns
@@ -156,22 +133,7 @@ class HMEDataLoaderFactory:
         DataLoader
             DataLoader for test data without shuffling and drop_last=False
         """
-        if self.processed:
-            dataset = HMEDatasetPreprocessed(
-                root=self.root,
-                split="test",
-                vocab=self.vocab,
-                transform=transform,
-                min_len=self.min_len,
-                max_len=self.max_len,
-            )
-        else:
-            dataset = HMEDatasetRaw(
-                root=self.root,
-                split="test",
-                vocab=self.vocab,
-                transform=transform,
-            )
+        dataset = self._get_dataset(split="test", transform=transform)
 
         return DataLoader(
             dataset=dataset,
@@ -186,16 +148,16 @@ class HMEDataLoaderFactory:
     def custom(
         self,
         split: str,
-        transform: Callable[[Tensor], Tensor] | None = None,
+        transform: Transformation = None,
         **kwargs,
     ) -> DataLoader:
         """Creates dataloader for custom split and DataLoader kwargs.
 
         Parameters
         ----------
-        split : str
+        split
             Dataset split name (e.g. `train`, `valid`, `test`)
-        transform : (Callable: `Tensor` -> `Tensor`) | None
+        transform
             Transform method passed to HMEDatasetRaw
         **kwargs
             Additional keyword arguments forwarded to `torch.utils.data.DataLoader`
@@ -206,22 +168,7 @@ class HMEDataLoaderFactory:
             Configured DataLoader for the specified split
         """
         split_name = split.lower()
-        if self.processed:
-            dataset = HMEDatasetPreprocessed(
-                root=self.root,
-                split=split_name,
-                vocab=self.vocab,
-                transform=transform,
-                min_len=self.min_len,
-                max_len=self.max_len,
-            )
-        else:
-            dataset = HMEDatasetRaw(
-                root=self.root,
-                split=split_name,
-                vocab=self.vocab,
-                transform=transform,
-            )
+        dataset = self._get_dataset(split=split_name, transform=transform)
 
         defaults = {
             "dataset": dataset,
@@ -235,3 +182,22 @@ class HMEDataLoaderFactory:
         defaults.update(kwargs)
 
         return DataLoader(**defaults)
+
+    def _get_dataset(self, split: str, transform: Transformation) -> HMEDataset:
+
+        kwargs = {
+            "root": self.root,
+            "split": split,
+            "vocab": self.vocab,
+            "transform": transform,
+        }
+        if self.processed:
+            ds = HMEDatasetPreprocessed(
+                **kwargs,
+                min_len=self.min_len,
+                max_len=self.max_len,
+            )
+        else:
+            ds = HMEDatasetRaw(**kwargs)
+
+        return ds

--- a/src/hand_to_tex/datasets/datamodule.py
+++ b/src/hand_to_tex/datasets/datamodule.py
@@ -19,6 +19,8 @@ class HMELightningDataModule(pl.LightningDataModule):
         batch_size: int = 32,
         num_workers: int = 4,
         pin_memory: bool = True,
+        min_len: int | None = None,
+        max_len: int | None = None,
         **kwargs: Any,
     ):
         super().__init__()
@@ -32,6 +34,9 @@ class HMELightningDataModule(pl.LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.pin_memory = pin_memory
+
+        self.min_len = min_len
+        self.max_len = max_len
 
         self.data_kwargs = kwargs
 
@@ -51,6 +56,8 @@ class HMELightningDataModule(pl.LightningDataModule):
                 batch_size=self.batch_size,
                 num_workers=self.num_workers,
                 pin_memory=self.pin_memory,
+                min_len=self.min_len,
+                max_len=self.max_len,
             )
 
         match stage:

--- a/src/hand_to_tex/datasets/dataset.py
+++ b/src/hand_to_tex/datasets/dataset.py
@@ -28,13 +28,13 @@ class _HMEDatasetBase(Dataset, ABC):
 
         Parameters
         ----------
-        root : Path | str
+        root
             Directory of all dataset files
-        split : str
+        split
             Name of the split, the path to .inkml files dir. will be root/split
-        vocab : LatexVocab | None
+        vocab
             Vocabulary for tokenization, default `LatexVocab.default()`
-        transform : (`Tensor` -> `Tensor`) | None
+        transform
             Optional transformation applied to features before returning
         """
         self.data_path = Path(root, split)
@@ -286,11 +286,11 @@ class HMEDatasetPreprocessed(_HMEDatasetBase):
             else:
                 self.data.append((fts, ts))
 
-        total, filtered = len(self.data), (short + long + has_inf + has_nan)
+        kept, filtered = len(self.data), (short + long + has_inf + has_nan)
 
         if filtered:
             logger.warning(
-                f"For min={min_len}, max={max_len} split={split} got short={short} | long={long} | has_inf={has_inf} | has_nan={has_nan} | total={total}/{filtered}"
+                f"For min={min_len}, max={max_len} split={split} got short={short} | long={long} | has_inf={has_inf} | has_nan={has_nan} | total={kept}/{kept + filtered}"
             )
 
     def __len__(self) -> int:

--- a/src/hand_to_tex/datasets/dataset.py
+++ b/src/hand_to_tex/datasets/dataset.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from torch.utils.data.dataset import Dataset
 
 from hand_to_tex.datasets.ink_data import InkData
-from hand_to_tex.utils import LatexVocab
+from hand_to_tex.utils import LatexVocab, logger
 
 
 class _HMEDatasetBase(Dataset, ABC):
@@ -256,10 +256,29 @@ class HMEDatasetPreprocessed(_HMEDatasetBase):
         split: str,
         vocab: LatexVocab | None = None,
         transform: Callable[[Tensor], Tensor] | None = None,
+        min_len: int | None = None,
+        max_len: int | None = None,
     ):
         super().__init__(root=root, split=split, vocab=vocab, transform=transform)
         data_path = Path(root, split + ".pt")
-        self.data = torch.load(data_path)
+        raw_data: list[tuple[torch.Tensor, torch.Tensor]] = torch.load(data_path)
+
+        self.data = []
+        filtered_out = 0
+        for fts, ts in raw_data:
+            ft_len = fts.size(0)
+
+            if (min_len is not None and ft_len < min_len) or (
+                max_len is not None and ft_len > max_len
+            ):
+                filtered_out += 1
+            else:
+                self.data.append((fts, ts))
+
+        if filtered_out:
+            logger.warning(
+                f"For min={min_len}, max={max_len}, split={split} filtered out: {filtered_out} samples"
+            )
 
     def __len__(self) -> int:
         return len(self.data)

--- a/src/hand_to_tex/datasets/dataset.py
+++ b/src/hand_to_tex/datasets/dataset.py
@@ -261,23 +261,36 @@ class HMEDatasetPreprocessed(_HMEDatasetBase):
     ):
         super().__init__(root=root, split=split, vocab=vocab, transform=transform)
         data_path = Path(root, split + ".pt")
-        raw_data: list[tuple[torch.Tensor, torch.Tensor]] = torch.load(data_path)
 
+        logger.info(f"Loading preprocessed HMEDataset from: {data_path}")
+        raw_data: list[tuple[torch.Tensor, torch.Tensor]] = torch.load(data_path, weights_only=True)
+
+        logger.info(f"Filtering data for split: {split}")
         self.data = []
-        filtered_out = 0
+        short, long, has_inf, has_nan = 0, 0, 0, 0
         for fts, ts in raw_data:
             ft_len = fts.size(0)
 
-            if (min_len is not None and ft_len < min_len) or (
-                max_len is not None and ft_len > max_len
-            ):
-                filtered_out += 1
+            if min_len is not None and ft_len < min_len:
+                short += 1
+
+            elif max_len is not None and ft_len > max_len:
+                long += 1
+
+            elif torch.isinf(fts).any():
+                has_inf += 1
+
+            elif torch.isnan(fts).any():
+                has_nan += 1
+
             else:
                 self.data.append((fts, ts))
 
-        if filtered_out:
+        total, filtered = len(self.data), (short + long + has_inf + has_nan)
+
+        if filtered:
             logger.warning(
-                f"For min={min_len}, max={max_len}, split={split} filtered out: {filtered_out} samples"
+                f"For min={min_len}, max={max_len} split={split} got short={short} | long={long} | has_inf={has_inf} | has_nan={has_nan} | total={total}/{filtered}"
             )
 
     def __len__(self) -> int:

--- a/src/hand_to_tex/models/components/experimental.py
+++ b/src/hand_to_tex/models/components/experimental.py
@@ -31,8 +31,8 @@ class PositionalEncoding(nn.Module):
         div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
 
         pe = torch.zeros(1, max_len, d_model)
-        pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
+        pe[0, :, 0::2] = torch.sin(position * div_term)
+        pe[0, :, 1::2] = torch.cos(position * div_term)
 
         self.register_buffer("pe", pe)
 

--- a/src/hand_to_tex/models/components/experimental.py
+++ b/src/hand_to_tex/models/components/experimental.py
@@ -217,6 +217,7 @@ class ExperimentalTransformer(nn.Module):
             tgt=tgt_emb,
             src_mask=None,
             tgt_mask=tgt_causal_mask,
+            tgt_is_causal=True,
             memory_mask=None,
             src_key_padding_mask=src_key_padding_mask,
             tgt_key_padding_mask=tgt_key_padding_mask,
@@ -282,6 +283,7 @@ class ExperimentalTransformer(nn.Module):
             tgt=tgt_emb,
             memory=memory,
             tgt_mask=tgt_causal_mask,
+            tgt_is_causal=True,
             tgt_key_padding_mask=tgt_key_padding_mask,
             memory_key_padding_mask=memory_key_padding_mask,
         )

--- a/src/hand_to_tex/models/components/experimental.py
+++ b/src/hand_to_tex/models/components/experimental.py
@@ -6,7 +6,7 @@ from torch import Tensor
 
 
 class PositionalEncoding(nn.Module):
-    """Sinusoidal positional encoding for sequence-first transformer inputs.
+    """Sinusoidal positional encoding for batch-first transformer inputs.
 
     The module expects tensors shaped `(batch, seq_len, d_model)` and adds
     deterministic sinusoidal vectors to each position before dropout.

--- a/src/hand_to_tex/models/components/experimental.py
+++ b/src/hand_to_tex/models/components/experimental.py
@@ -6,26 +6,61 @@ from torch import Tensor
 
 
 class PositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding for sequence-first transformer inputs.
+
+    The module expects tensors shaped `(batch, seq_len, d_model)` and adds
+    deterministic sinusoidal vectors to each position before dropout.
+    """
+
     def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 5000):
+        """Precompute sinusoidal encodings and register them as a buffer.
+
+        Parameters
+        ----------
+        d_model:
+            Embedding size of the model.
+        dropout:
+            Dropout probability applied after positional addition.
+        max_len:
+            Maximum sequence length covered by the precomputed table.
+        """
         super().__init__()
         self.dropout = nn.Dropout(p=dropout)
 
         position = torch.arange(max_len).unsqueeze(1)
         div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
 
-        pe = torch.zeros(max_len, d_model)
+        pe = torch.zeros(1, max_len, d_model)
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
 
         self.register_buffer("pe", pe)
 
     def forward(self, x: Tensor) -> Tensor:
+        """Add position encodings to an input batch.
+
+        Parameters
+        ----------
+        x:
+            Input tensor of shape `(B, T, D)`.
+
+        Returns
+        -------
+        Tensor
+            Tensor with positional information added, same shape as input.
+        """
         seq_len = x.size(1)
-        x = x + self.pe[:seq_len, :].unsqueeze(0)  # type: ignore
+        x = x + self.pe[:, :seq_len, :]
         return self.dropout(x)
 
 
 class ExperimentalTransformer(nn.Module):
+    """Sequence-to-sequence transformer for handwriting feature decoding.
+
+    Source inputs are expected as `(B, T_src, in_channels)` float features.
+    Target inputs are `(B, T_tgt)` token ids used for teacher forcing.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -38,15 +73,41 @@ class ExperimentalTransformer(nn.Module):
         dim_feedforward: int = 1024,
         dropout: float = 0.1,
     ):
+        """Initialize encoder/decoder stack and projection heads.
+
+        Parameters
+        ----------
+        in_channels:
+            Number of per-timestep source features.
+        vocab_size:
+            Size of output token vocabulary.
+        pad_idx:
+            Vocabulary index used for padding tokens.
+        d_model:
+            Hidden embedding size used throughout the transformer.
+        nhead:
+            Number of attention heads.
+        num_encoder_layers:
+            Number of transformer encoder blocks.
+        num_decoder_layers:
+            Number of transformer decoder blocks.
+        dim_feedforward:
+            Feed-forward width in transformer blocks.
+        dropout:
+            Dropout probability used in transformer and positional layers.
+        """
         super().__init__()
         self.pad_idx = pad_idx
         self.d_model = d_model
 
+        self.conv1 = nn.Conv1d(in_channels, d_model, kernel_size=5, stride=2, padding=1)
+        self.conv2 = nn.Conv1d(d_model, d_model, kernel_size=5, stride=2, padding=2)
+
         self.input_proj = nn.Sequential(
-            nn.Conv1d(in_channels, d_model, kernel_size=5, stride=2, padding=1),
+            self.conv1,
             nn.BatchNorm1d(d_model),
             nn.GELU(),
-            nn.Conv1d(d_model, d_model, kernel_size=5, stride=2, padding=2),
+            self.conv2,
             nn.BatchNorm1d(d_model),
             nn.GELU(),
         )
@@ -71,19 +132,72 @@ class ExperimentalTransformer(nn.Module):
         self.fc_out = nn.Linear(d_model, vocab_size)
 
     def _get_padding_mask(self, lengths: Tensor, max_len: int) -> Tensor:
-        device = lengths.device
-        mask = torch.arange(max_len, device=device).expand(
-            lengths.size(0), max_len
-        ) >= lengths.unsqueeze(1)
-        return mask
+        """Build a boolean key-padding mask from sequence lengths.
+
+        Parameters
+        ----------
+        lengths:
+            Tensor `(B,)` with valid sequence lengths.
+        max_len:
+            Maximum sequence length in the padded batch.
+
+        Returns
+        -------
+        Tensor
+            Boolean mask `(B, max_len)` where `True` marks padding positions.
+        """
+        steps = torch.arange(max_len, device=lengths.device).unsqueeze(0)
+        return steps >= lengths.unsqueeze(1)
+
+    @staticmethod
+    def _conv1d_output_lengths(lengths: Tensor, conv: nn.Conv1d) -> Tensor:
+        """Compute output lengths after applying a Conv1d layer.
+
+        Uses the exact Conv1d formula:
+        `L_out = floor((L_in + 2P - D*(K-1) - 1) / S) + 1`.
+        """
+        kernel_size = conv.kernel_size[0]
+        stride = conv.stride[0]
+        padding = conv.padding[0]
+        dilation = conv.dilation[0]
+
+        numerator = lengths + 2 * padding - dilation * (kernel_size - 1) - 1
+        return torch.div(numerator, stride, rounding_mode="floor") + 1
 
     def _calc_downsampled_lengths(self, lengths: Tensor) -> Tensor:
+        """Compute source lengths after the two strided projection convolutions.
 
-        conv1_len = ((lengths + 2 * 2 - 5) // 2) + 1
-        conv2_len = ((conv1_len + 2 * 2 - 5) // 2) + 1
-        return conv2_len
+        Returns
+        -------
+        Tensor
+            Tensor `(B,)` with projected source lengths.
+        """
+        conv1_len = self._conv1d_output_lengths(lengths, self.conv1)
+        conv2_len = self._conv1d_output_lengths(conv1_len, self.conv2)
+        return conv2_len.clamp_min(0)
+
+    @staticmethod
+    def _build_causal_mask(seq_len: int, device: torch.device) -> Tensor:
+        """Create a decoder causal mask where future positions are blocked."""
+        return nn.Transformer.generate_square_subsequent_mask(seq_len, device=device).bool()
 
     def forward(self, src: Tensor, src_lengths: Tensor, tgt: Tensor) -> Tensor:
+        """Run the full teacher-forced transformer pass.
+
+        Parameters
+        ----------
+        src:
+            Source feature tensor `(B, T_src, C)`.
+        src_lengths:
+            Valid source lengths `(B,)` before convolutional downsampling.
+        tgt:
+            Target token ids `(B, T_tgt)` used as decoder input.
+
+        Returns
+        -------
+        Tensor
+            Decoder logits `(B, T_tgt, vocab_size)`.
+        """
         src_conv = src.transpose(1, 2)
         src_features = self.input_proj(src_conv).transpose(1, 2)
 
@@ -96,9 +210,7 @@ class ExperimentalTransformer(nn.Module):
         tgt_key_padding_mask = tgt == self.pad_idx
 
         tgt_seq_len = tgt.size(1)
-        tgt_causal_mask = nn.Transformer.generate_square_subsequent_mask(
-            tgt_seq_len, device=tgt.device
-        ).bool()
+        tgt_causal_mask = self._build_causal_mask(tgt_seq_len, tgt.device)
 
         output = self.transformer(
             src=src_emb,
@@ -113,15 +225,27 @@ class ExperimentalTransformer(nn.Module):
 
         return self.fc_out(output)
 
-    def encode(
-        self, src: torch.Tensor, src_lengths: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def encode(self, src: Tensor, src_lengths: Tensor) -> tuple[Tensor, Tensor]:
+        """Encode source features into memory for autoregressive decoding.
+
+        Parameters
+        ----------
+        src:
+            Source feature tensor `(B, T_src, C)`.
+        src_lengths:
+            Valid source lengths `(B,)` before convolutional downsampling.
+
+        Returns
+        -------
+        tuple[Tensor, Tensor]
+            - `memory`: encoder output `(B, T_src', D)`
+            - `src_key_padding_mask`: boolean mask `(B, T_src')`
+        """
         src_conv = src.transpose(1, 2)
 
         src_features = self.input_proj(src_conv).transpose(1, 2)
 
-        conv1_len = ((src_lengths + 2 * 2 - 5) // 2) + 1
-        new_src_lengths = ((conv1_len + 2 * 2 - 5) // 2) + 1
+        new_src_lengths = self._calc_downsampled_lengths(src_lengths)
 
         src_emb = self.src_pe(src_features)
 
@@ -132,12 +256,26 @@ class ExperimentalTransformer(nn.Module):
         return memory, src_key_padding_mask
 
     def decode(self, tgt: Tensor, memory: Tensor, memory_key_padding_mask: Tensor) -> Tensor:
+        """Decode a target prefix given encoder memory.
+
+        Parameters
+        ----------
+        tgt:
+            Decoder input token ids `(B, T_tgt)`.
+        memory:
+            Encoder memory `(B, T_src', D)`.
+        memory_key_padding_mask:
+            Boolean mask `(B, T_src')` marking padded memory positions.
+
+        Returns
+        -------
+        Tensor
+            Decoder logits `(B, T_tgt, vocab_size)`.
+        """
 
         tgt_emb = self.tgt_pe(self.tgt_tok_emb(tgt) * math.sqrt(self.d_model))
 
-        tgt_causal_mask = nn.Transformer.generate_square_subsequent_mask(
-            tgt.size(1), device=tgt.device
-        )
+        tgt_causal_mask = self._build_causal_mask(tgt.size(1), tgt.device)
         tgt_key_padding_mask = tgt == self.pad_idx
 
         out = self.transformer.decoder(

--- a/src/hand_to_tex/utils/interactive.py
+++ b/src/hand_to_tex/utils/interactive.py
@@ -128,7 +128,6 @@ class HMEDrawingApp:
         self.current_trace = []
         self.start_time = None
 
-        # Reset silnika renderującego
         self.text_obj.set_color("black")
         self.text_obj.set_text("Draw a symbol and press Generate")
         self.latex_canvas.draw()

--- a/src/hand_to_tex/utils/interactive.py
+++ b/src/hand_to_tex/utils/interactive.py
@@ -1,0 +1,171 @@
+import time
+import tkinter as tk
+
+import matplotlib.pyplot as plt
+import torch
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+
+from hand_to_tex.datasets.dataset import _HMEDatasetBase
+from hand_to_tex.datasets.ink_data import InkData
+
+
+class HMEDrawingApp:
+    def __init__(self, master, model, device):
+        self.master = master
+        self.model = model
+        self.device = device
+
+        self.master.title("HME Interactive Inference")
+        self.master.geometry("800x650")
+        self.master.protocol("WM_DELETE_WINDOW", self.on_closing)
+
+        self.canvas = tk.Canvas(self.master, bg="white", cursor="crosshair")
+        self.canvas.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        self.btn_frame = tk.Frame(self.master)
+        self.btn_frame.pack(fill=tk.X, padx=10, pady=5)
+
+        self.btn_predict = tk.Button(
+            self.btn_frame,
+            text="Generate TeX",
+            command=self.predict,
+            bg="lightgreen",
+            font=("Arial", 14, "bold"),
+        )
+        self.btn_predict.pack(side=tk.LEFT, padx=5)
+
+        self.btn_clear = tk.Button(
+            self.btn_frame, text="Clear", command=self.clear, font=("Arial", 14)
+        )
+        self.btn_clear.pack(side=tk.LEFT, padx=5)
+
+        self.btn_undo = tk.Button(
+            self.btn_frame, text="Undo", command=self.undo_last_trace, font=("Arial", 14)
+        )
+        self.btn_undo.pack(side=tk.LEFT, padx=5)
+
+        self.fig, self.ax = plt.subplots(figsize=(6, 1.5))
+        self.fig.patch.set_facecolor("#f0f0f0")
+        self.ax.axis("off")
+
+        self.text_obj = self.ax.text(
+            0.5, 0.5, "Draw a symbol and press Generate", ha="center", va="center", fontsize=18
+        )
+
+        self.latex_canvas = FigureCanvasTkAgg(self.fig, master=self.master)
+        self.latex_canvas.get_tk_widget().pack(pady=10)
+
+        self.canvas.bind("<Button-1>", self.start_stroke)
+        self.canvas.bind("<B1-Motion>", self.draw)
+        self.canvas.bind("<ButtonRelease-1>", self.end_stroke)
+
+        self.traces = []
+        self.current_trace = []
+        self.start_time = None
+        self.last_x = None
+        self.last_y = None
+
+    def start_stroke(self, event):
+        if self.start_time is None:
+            self.start_time = time.time()
+
+        t = time.time() - self.start_time
+        self.current_trace = [(float(event.x), float(event.y), t)]
+        self.last_x = event.x
+        self.last_y = event.y
+
+    def draw(self, event):
+        t = time.time() - self.start_time  # type: ignore
+        self.current_trace.append((float(event.x), float(event.y), t))
+
+        self.canvas.create_line(
+            self.last_x,  # type:ignore
+            self.last_y,  # type:ignore
+            event.x,
+            event.y,
+            width=3,
+            fill="black",
+            capstyle=tk.ROUND,
+            smooth=tk.TRUE,
+        )
+        self.last_x = event.x
+        self.last_y = event.y
+
+    def end_stroke(self, event):
+        if len(self.current_trace) > 1:
+            self.traces.append(self.current_trace)
+        self.current_trace = []
+
+    def _redraw_traces(self):
+        self.canvas.delete("all")
+
+        for trace in self.traces:
+            for i in range(1, len(trace)):
+                x1, y1, _ = trace[i - 1]
+                x2, y2, _ = trace[i]
+                self.canvas.create_line(
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    width=3,
+                    fill="black",
+                    capstyle=tk.ROUND,
+                    smooth=tk.TRUE,
+                )
+
+    def undo_last_trace(self):
+        if self.current_trace:
+            self.current_trace = []
+
+        if self.traces:
+            self.traces.pop()
+            self._redraw_traces()
+
+    def clear(self):
+        self.canvas.delete("all")
+        self.traces = []
+        self.current_trace = []
+        self.start_time = None
+
+        # Reset silnika renderującego
+        self.text_obj.set_color("black")
+        self.text_obj.set_text("Draw a symbol and press Generate")
+        self.latex_canvas.draw()
+
+    def predict(self):
+        if not self.traces:
+            self.text_obj.set_color("red")
+            self.text_obj.set_text("No traces found!")
+            self.latex_canvas.draw()
+            return
+
+        ink = InkData(
+            tag="test", sample_id="interactive_demo", tex_raw="", tex_norm="", traces=self.traces
+        )
+
+        features = _HMEDatasetBase.extract_features(ink)
+
+        if features.size(0) == 0:
+            self.text_obj.set_color("red")
+            self.text_obj.set_text("Invalid traces")
+            self.latex_canvas.draw()
+            return
+
+        features_batched = features.unsqueeze(0).to(self.device)
+        lengths = torch.tensor([features.size(0)], dtype=torch.long, device=self.device)
+
+        with torch.inference_mode():
+            generated_tokens = self.model.generate(src=features_batched, src_lengths=lengths)
+
+        predicted_expr = self.model._to_expr(generated_tokens[0])
+
+        self.text_obj.set_color("blue")
+        self.text_obj.set_text(rf"${predicted_expr}$")
+        self.latex_canvas.draw()
+
+    def on_closing(self):
+        """Cleanly exit the application and release Matplotlib memory."""
+        plt.close(self.fig)
+        self.master.quit()
+        self.master.destroy()

--- a/tests/datasets/test_dataloader.py
+++ b/tests/datasets/test_dataloader.py
@@ -22,7 +22,14 @@ class TestHMEDataLoaderFactory:
     def test_train_uses_shuffle_and_drop_last(self, tmp_path: Path, sample_inkml: Path, vocab):
         root = _prepare_splits_with_sample(tmp_path, sample_inkml)
         factory = HMEDataLoaderFactory(
-            root=root, processed=False, vocab=vocab, batch_size=1, num_workers=0, pin_memory=False
+            root=root,
+            processed=False,
+            vocab=vocab,
+            batch_size=1,
+            num_workers=0,
+            pin_memory=False,
+            min_len=None,
+            max_len=None,
         )
 
         train_loader = factory.train()
@@ -33,7 +40,14 @@ class TestHMEDataLoaderFactory:
     def test_valid_and_test_use_sequential_sampler(self, tmp_path: Path, sample_inkml: Path, vocab):
         root = _prepare_splits_with_sample(tmp_path, sample_inkml)
         factory = HMEDataLoaderFactory(
-            root=root, vocab=vocab, processed=False, batch_size=1, num_workers=0, pin_memory=False
+            root=root,
+            vocab=vocab,
+            processed=False,
+            batch_size=1,
+            num_workers=0,
+            pin_memory=False,
+            min_len=None,
+            max_len=None,
         )
 
         valid_loader = factory.valid()
@@ -47,7 +61,14 @@ class TestHMEDataLoaderFactory:
     def test_custom_overrides_defaults(self, tmp_path: Path, sample_inkml: Path, vocab):
         root = _prepare_splits_with_sample(tmp_path, sample_inkml)
         factory = HMEDataLoaderFactory(
-            root=root, vocab=vocab, processed=False, batch_size=4, num_workers=0, pin_memory=False
+            root=root,
+            vocab=vocab,
+            processed=False,
+            batch_size=4,
+            num_workers=0,
+            pin_memory=False,
+            min_len=None,
+            max_len=None,
         )
 
         loader = factory.custom("valid", batch_size=2, shuffle=True, drop_last=True)
@@ -59,7 +80,14 @@ class TestHMEDataLoaderFactory:
     def test_iteration_returns_collated_batch(self, tmp_path: Path, sample_inkml: Path, vocab):
         root = _prepare_splits_with_sample(tmp_path, sample_inkml)
         factory = HMEDataLoaderFactory(
-            root=root, vocab=vocab, processed=False, batch_size=1, num_workers=0, pin_memory=False
+            root=root,
+            vocab=vocab,
+            processed=False,
+            batch_size=1,
+            num_workers=0,
+            pin_memory=False,
+            min_len=None,
+            max_len=None,
         )
 
         loader = factory.valid()
@@ -75,7 +103,14 @@ class TestHMEDataLoaderFactory:
     def test_transform_applied_in_loader(self, tmp_path: Path, sample_inkml: Path, vocab):
         root = _prepare_splits_with_sample(tmp_path, sample_inkml)
         factory = HMEDataLoaderFactory(
-            root=root, vocab=vocab, processed=False, batch_size=1, num_workers=0, pin_memory=False
+            root=root,
+            vocab=vocab,
+            processed=False,
+            batch_size=1,
+            num_workers=0,
+            pin_memory=False,
+            min_len=None,
+            max_len=None,
         )
 
         def negate(x: torch.Tensor) -> torch.Tensor:

--- a/tests/scripts/test_init.py
+++ b/tests/scripts/test_init.py
@@ -6,9 +6,9 @@ import pytest
 from scripts import init
 
 
-def test_run_init_executes_commands_in_order():
+def test_run_init_executes_standard_commands_in_order():
     with patch("scripts.init.subprocess.run") as run_mock:
-        init.run_init(threads=12, mock=False)
+        init.run_init(threads=12, mode="standard")
 
     assert run_mock.call_args_list == [
         call(["htt-get-data", "--full"], check=True),
@@ -21,7 +21,7 @@ def test_run_init_executes_commands_in_order():
 
 def test_run_init_executes_mock_commands_in_order():
     with patch("scripts.init.subprocess.run") as run_mock:
-        init.run_init(threads=3, mock=True)
+        init.run_init(threads=3, mode="mock")
 
     assert run_mock.call_args_list == [
         call(["htt-get-data"], check=True),
@@ -29,34 +29,47 @@ def test_run_init_executes_mock_commands_in_order():
     ]
 
 
+def test_run_init_executes_extended_commands_in_order():
+    with patch("scripts.init.subprocess.run") as run_mock:
+        init.run_init(threads=5, mode="extended")
+
+    assert run_mock.call_args_list == [
+        call(["htt-get-data", "--full"], check=True),
+        call(
+            ["htt-preprocess", "--threads", "5"] + init.PREPROCESS_EXTENDED_PARAMS,
+            check=True,
+        ),
+    ]
+
+
 def test_main_passes_threads_to_run_init(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["htt-init", "--threads", "7"])
     captured = {}
 
-    def fake_run_init(threads: int, mock: bool) -> None:
+    def fake_run_init(threads: int, mode: str) -> None:
         captured["threads"] = threads
-        captured["mock"] = mock
+        captured["mode"] = mode
 
     monkeypatch.setattr(init, "run_init", fake_run_init)
     init.main()
 
     assert captured["threads"] == 7
-    assert captured["mock"] is False
+    assert captured["mode"] == "standard"
 
 
-def test_main_passes_mock_flag_to_run_init(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["htt-init", "--threads", "2", "--mock"])
+def test_main_passes_mode_to_run_init(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["htt-init", "--threads", "2", "--mode", "mock"])
     captured = {}
 
-    def fake_run_init(threads: int, mock: bool) -> None:
+    def fake_run_init(threads: int, mode: str) -> None:
         captured["threads"] = threads
-        captured["mock"] = mock
+        captured["mode"] = mode
 
     monkeypatch.setattr(init, "run_init", fake_run_init)
     init.main()
 
     assert captured["threads"] == 2
-    assert captured["mock"] is True
+    assert captured["mode"] == "mock"
 
 
 def test_main_rejects_non_positive_threads(monkeypatch):


### PR DESCRIPTION

**Major documentation and usability improvements:**

* Completely rewrote and expanded the `README.md` 

**New features and CLI tools:**

* Added `htt-demo` CLI entrypoint and implementation (`scripts/demo.py`) for running batch inference on InkML files/directories and launching an interactive handwriting-to-TeX canvas. This enables immediate model testing and demonstrations without manual scripting. [[1]](diffhunk://#diff-911ee836b2798f88a488926dc6e39087c3b0cc2bcab98b67d81ef222d6eca81bR1-R126) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R61)

**Data pipeline and configuration enhancements:**

* Refactored the data initialization pipeline (`scripts/init.py`, `htt-init`) to support three modes: `mock`, `standard`, and `extended`, each with different dataset sizes and preprocessing strategies. The CLI now uses a `--mode` argument instead of `--mock`, and the help text is much more descriptive. [[1]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL6-R16) [[2]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dR26-R47) [[3]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL43-R57) [[4]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL52-R82)
* Updated preprocessing to use lower-precision types for features (`float16`) and tokens (`int16`) to reduce memory usage and disk space.
* The collate function and dataloader now ensure correct tensor types (`float32` for features, `long` for tokens) and support minimum/maximum length filtering via new `min_len`/`max_len` options, which are now configurable in `default.yaml`. [[1]](diffhunk://#diff-48cb1adf87db4f73021d3d83eead483c2b5ed3b3f8175df0a3836d87b284807dL45-R46) [[2]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807R33-R34) [[3]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807R59-R60) [[4]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L74-R93) [[5]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L101-R134) [[6]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L127-R174) [[7]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5R150)

**Configuration and training improvements:**

* Changed the default experiment name in WandB logger to reflect the new extended dataset mode and set the model to not use a pretrained checkpoint by default. [[1]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5L11-R11) [[2]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5L132-R132)

These changes collectively make the project easier to use, more robust, and ready for both quick experimentation and full-scale training.

---

**References:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R226) [[2]](diffhunk://#diff-911ee836b2798f88a488926dc6e39087c3b0cc2bcab98b67d81ef222d6eca81bR1-R126) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R61) [[4]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL6-R16) [[5]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dR26-R47) [[6]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL43-R57) [[7]](diffhunk://#diff-4c7af644c4e30b9e10e56e5634386ebcf48d0b24afb32e4afe077cddc7c45b6dL52-R82) [[8]](diffhunk://#diff-99daf323988466cfa4fa6799e04c71852ce53d593078216679403dcc48dfda17L43-R49) [[9]](diffhunk://#diff-48cb1adf87db4f73021d3d83eead483c2b5ed3b3f8175df0a3836d87b284807dL45-R46) [[10]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807R33-R34) [[11]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807R59-R60) [[12]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L74-R93) [[13]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L101-R134) [[14]](diffhunk://#diff-5630ce299c920b7e0ea0a2629c2f237d133b10e36294974443a443d428d90807L127-R174) [[15]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5R150) [[16]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5L11-R11) [[17]](diffhunk://#diff-e69eb813cac10cbe6915b6ca52647f37ee3eb7e0a8821fcd76f23aa503a9b2f5L132-R132)